### PR TITLE
POC: Europeana annotation handling

### DIFF
--- a/__tests__/integration/mirador/index.html
+++ b/__tests__/integration/mirador/index.html
@@ -14,12 +14,7 @@
      var miradorInstance = Mirador.viewer({
        id: 'mirador',
        windows: [{
-         manifestId: 'https://iiif.harvardartmuseums.org/manifests/object/299843',
-         canvasId: 'https://iiif.harvardartmuseums.org/manifests/object/299843/canvas/canvas-47174892',
-         thumbnailNavigationPosition: 'far-bottom',
-       },
-       {
-         manifestId: 'https://iiif.bodleian.ox.ac.uk/iiif/manifest/e32a277e-91e2-4a6d-8ba6-cc4bad230410.json',
+         manifestId: 'https://iiif.europeana.eu/presentation/9200396/BibliographicResource_3000118436341/manifest',
        }],
        manifests: {
          "https://media.nga.gov/public/manifests/nga_highlights.json": { provider: "National Gallery of Art"},

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.50",
     "@researchgate/react-intersection-observer": "^1.0.0",
+    "axios": "^0.19.2",
     "classnames": "^2.2.6",
     "clsx": "^1.0.4",
     "deepmerge": "^3.3.0",

--- a/src/state/actions/annotation.js
+++ b/src/state/actions/annotation.js
@@ -1,4 +1,5 @@
 import fetch from 'isomorphic-unfetch';
+import uniq from 'lodash/uniq';
 import ActionTypes from './action-types';
 
 /**
@@ -51,6 +52,105 @@ export function receiveAnnotationFailure(targetId, annotationId, error) {
 }
 
 /**
+ * coerceAnnotationToCanvasId - hack to force `on` attribute to canvas ID
+ *
+ * @param  {String} targetId
+ * @param  {Object} annotationJson
+ * TODO: also handle v3 target attribute
+ */
+function coerceAnnotationToCanvasId(targetId, annotationJson) {
+  const coercedJson = Object.assign({}, annotationJson);
+
+  coercedJson.resources = annotationJson.resources.map((resource) => {
+    const coercedResource = Object.assign({}, resource);
+    coercedResource.on = [].concat(coercedResource.on);
+    if (coercedResource.on[0].includes('xywh=')) {
+      coercedResource.on[0] = coercedResource.on[0].replace(/^[^#]+/, targetId); // replace up to hash
+    }
+    return coercedResource;
+  });
+
+  return coercedJson;
+}
+
+/**
+ * filterAnnotationResources - filter annotation resources
+ *
+ * @param  {Object} annotationJson
+ * TODO: make this into a configuration option
+ */
+function filterAnnotationResources(annotationJson) {
+  const filteredJson = Object.assign({}, annotationJson);
+
+  filteredJson.resources = annotationJson.resources.filter(resource => resource.dcType === 'Line');
+
+  return filteredJson;
+}
+
+/**
+ * fetchAnnotationResourcesFulltext - fetch annotation fulltext
+ *
+ * @param  {Object} annotationJson
+ */
+function fetchAnnotationResourcesFulltext(annotationJson) {
+  const urls = annotationJson.resources
+    .filter(resource => !resource.resource.chars && resource.resource['@id'])
+    .map(resource => resource.resource['@id'].split('#')[0]);
+
+  const fulltext = {};
+
+  const fetches = uniq(urls).map(url => fetch(url)
+    .then(response => response.json())
+    .then((json) => {
+      if (json.type === 'FullTextResource') fulltext[url] = json.value;
+    }));
+
+  return Promise.all(fetches).then(() => fulltext);
+}
+
+/**
+ * filterAnnotationResources - dereference annotation resources
+ *
+ * @param  {Object} annotationJson
+ */
+function dereferenceAnnotationResources(annotationJson) {
+  return fetchAnnotationResourcesFulltext(annotationJson)
+    .then((fulltext) => {
+      // console.log('fulltext', fulltext);
+      const dereferencedJson = Object.assign({}, annotationJson);
+
+      dereferencedJson.resources = annotationJson.resources.map((resource) => {
+        const dereferencedResource = Object.assign({}, resource);
+        if (dereferencedResource.resource.chars || !dereferencedResource.resource['@id']) {
+          return dereferencedResource;
+        }
+
+        const url = dereferencedResource.resource['@id'].split('#')[0];
+        if (!fulltext[url]) return dereferencedResource;
+
+        const fragment = dereferencedResource.resource['@id'].split('#')[1];
+
+        dereferencedResource.resource.chars = fulltext[url];
+
+        if (fragment) {
+          const charMatch = fragment.match(/char=(\d+),(\d+)$/);
+          if (charMatch) {
+            dereferencedResource.resource.chars = dereferencedResource.resource.chars.slice(
+              Number(charMatch[1]),
+              Number(charMatch[2]) + 1,
+            );
+            // console.log('annotation chars', dereferencedResource.resource.chars);
+          }
+        }
+
+        return dereferencedResource;
+      });
+
+      return dereferencedJson;
+    });
+}
+
+/**
  * fetchAnnotation - action creator
  *
  * @param  {String} annotationId
@@ -59,8 +159,12 @@ export function receiveAnnotationFailure(targetId, annotationId, error) {
 export function fetchAnnotation(targetId, annotationId) {
   return ((dispatch) => {
     dispatch(requestAnnotation(targetId, annotationId));
+
     return fetch(annotationId)
       .then(response => response.json())
+      .then(json => filterAnnotationResources(json))
+      .then(json => coerceAnnotationToCanvasId(targetId, json))
+      .then(json => dereferenceAnnotationResources(json))
       .then(json => dispatch(receiveAnnotation(targetId, annotationId, json)))
       .catch(error => dispatch(receiveAnnotationFailure(targetId, annotationId, error)));
   });


### PR DESCRIPTION
This proof-of-concept for handling Europeana fulltext annotations _linked to_ from Annotation Lists modifies the core Mirador annotation state action with three custom handlers to process **and modify the content** of the Annotation List response before dispatching it to `receiveAnnotation`:
1. Filter annotation resources by granularity, i.e. to those with `resource.dcType` being "Line", as the stock implementation of annotation display by Mirador does not lend itself well to concurrent display of all the available levels of granularity, i.e. Page, Block, Line and Word.
2. Overwrite the `on` property of all annotation resources to reference the requested Canvas URI, and not an image, as required by the IIIF Presentation API v2 specification, and enforced by Mirador's OpenSeaDragonViewer component.
   1. I suspect this is a bug in our implementation of annotation lists / pages, and if so this would only be a temporary workaround.
3. Dereference the annotation resource URIs and if they are of `type` "FullTextResource" use their `value` to populate the annotation resource's `chars` property. Fetching is done using axios, adding that as a non-dev dependency Mirador, and not using unfetch which is already included as the latter results in display issues with some of the character encodings in use in our fulltext annotations.
   1. I suspect that we may have encoding issues in our annotations as JSON should always be UTF-encoded, but given that axios handles it fine out-of-the-box, am not certain.